### PR TITLE
Example: Game entity database

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -8,6 +8,9 @@
     },
     "ColorPalette": {
       "main": "test/ColorPalette.mo"
+    },
+    "GameEntities": {
+      "main": "test/GameEntities.mo"
     }
   },
   "defaults": {

--- a/examples/game/Types.mo
+++ b/examples/game/Types.mo
@@ -1,0 +1,54 @@
+// see https://forum.dfinity.org/t/crud-with-uuid-generation-need-some-direction/1033
+module {
+  public type Id = Nat;
+  public type Name = Text;
+
+  public type NamedEntity = {
+    name : Name; // the name need not be unique
+    entity : Entity; // (arbitrarily complex entity data)
+  };
+
+  /// distinguish different types of entities
+  public type Entity = {
+    #rarity : Rarity;
+    #monster : Monster;
+  };
+
+  /// Entity type: Rarities
+  public type Rarity = {
+    kind : RarityKind;
+    quantity : Nat; // units?
+  };
+
+  /// distinguish different types of rarities
+  public type RarityKind = {
+    #gold;
+    #silver;
+    #unobtanium;
+  };
+
+  /// Entity type: Monsters
+  public type Monster = {
+    kind : MonsterKind;
+    data : MonsterData;
+  };
+
+  /// data common to all monsters
+  public type MonsterData = {
+    health : Nat;
+    // to do -- data common to all monsters
+  };
+
+  /// distinguish different kinds of monsters
+  public type MonsterKind = {
+    #goblin;
+    #dragon: DragonColor;
+  };
+
+  /// distinguish different kinds of dragons
+  public type DragonColor = {
+    #green;
+    #gold;
+    #red;
+  };
+}

--- a/src/Database.mo
+++ b/src/Database.mo
@@ -5,6 +5,7 @@ import Buffer "mo:base/Buffer";
 
 import TrieMap "mo:base/TrieMap";
 import RBTree "mo:base/RBTree";
+import Iter "mo:base/Iter";
 
 module {
 
@@ -17,7 +18,7 @@ module {
   {
 
     // to do -- two possible representations, depending on the identifier kind:
-    var entries : TrieMap.TrieMap<Id, CRU> = switch idKind {
+    var _entries : TrieMap.TrieMap<Id, CRU> = switch idKind {
       case (#hash(h)) {
              TrieMap.TrieMap<Id, CRU>(idEqual, h)
            };
@@ -33,13 +34,13 @@ module {
     public func create(cru:CRU) : Id {
       let x : Id = idCreate(cru, lastCreated);
       lastCreated := ?x;
-      entries.put(x, cru);
+      _entries.put(x, cru);
       logBuffer.add(#create(x, cru));
       x
     };
 
     public func read(id:Id) : Res<CRU> {
-      switch (entries.get(id)) {
+      switch (_entries.get(id)) {
         case null {
           logBuffer.add(#read(id, #err(#invalidId)));
           #err(#invalidId)
@@ -53,7 +54,7 @@ module {
     };
 
     public func update(id:Id, cru:CRU) : Res<()> {
-      switch (entries.replace(id, cru)) {
+      switch (_entries.replace(id, cru)) {
         case null {
           logBuffer.add(#update(id, cru, ?#invalidId));
           #err(#invalidId)
@@ -66,7 +67,7 @@ module {
     };
 
     public func delete(id:Id) : Res<()> {
-      switch (entries.remove(id)) {
+      switch (_entries.remove(id)) {
         case null { #err(#invalidId) };
         case (?_) { #ok(()) };
       }
@@ -76,8 +77,11 @@ module {
       let l = logBuffer.clone();
       logBuffer.clear();
       l
-    }
+    };
 
+    public func entries() : Iter.Iter<(Id, CRU)> {
+      _entries.entries()
+    };
   };
 
 }

--- a/test.sh
+++ b/test.sh
@@ -29,3 +29,10 @@ echo
 
 dfx canister install ColorPalette
 dfx canister call ColorPalette selfTest '()'
+
+echo
+echo == Game entity test.
+echo
+
+dfx canister install GameEntities
+dfx canister call GameEntities selfTest '()'

--- a/test/GameEntities.mo
+++ b/test/GameEntities.mo
@@ -1,0 +1,45 @@
+/*
+ Attempts to address this question:
+ https://forum.dfinity.org/t/crud-with-uuid-generation-need-some-direction/1033
+*/
+import Debug "mo:base/Debug";
+import Nat "mo:base/Nat";
+import Hash "mo:base/Hash";
+
+import Buffer "mo:base/Buffer";
+import Iter "mo:base/Iter";
+
+import Db "../src/Database";
+
+import Types "../examples/game/Types";
+
+actor {
+
+  public type Id = Types.Id; // Nat for now (not Text, as in the forum question)
+  public type DbRow = Types.NamedEntity;
+  public type Entity = Types.Entity;
+
+  // A database of named entities, each (uniquely) identified by a number
+  flexible var db = Db.Database<Id, DbRow>(
+    func (_, last) {
+      switch last { case null 0; case (?x) x + 1 };
+    },
+    Nat.equal,
+    #hash(Hash.hash),
+  );
+
+  /// create an entity, assigning a unique ID
+  public func createEntity(n : Text, e : Entity) : async Id {
+    db.create({name=n; entity=e})
+  };
+
+  /// get all of the entries in the database thus far
+  public func readAll() : async [(Id, DbRow)] {
+    Iter.toArray(db.entries())
+  };
+
+  public func selfTest() : () {
+     // to do
+     Debug.print "success"
+  };
+}


### PR DESCRIPTION
- Demonstrates another UUID generation example for the `create` operation
- Demonstrates a somewhat complex/interesting use of Motoko's variant and record types (aka "sum and product types") for defining a typed representation of entity data